### PR TITLE
Add .devcontainer to standardize environment and automate repo setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,36 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-20.04
+
+SHELL [ "bash", "-c" ]
+
+# update apt and install packages
+RUN apt update && \
+    apt install -yq \
+        build-essential \
+        cmake \
+        dkms \
+        ffmpeg \
+        libturbojpeg \
+        libgl1-mesa-glx \
+        python3-dev \
+        ninja-build \
+        jq \
+        jp \
+        tree \
+        tldr
+
+# add git-lfs and install
+RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash && \
+    sudo apt-get install -yq git-lfs && \
+    git lfs install
+
+############################################
+# Setup user
+############################################
+
+USER vscode
+
+# Setup conda
+RUN cd /tmp && \
+    wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
+    bash ./Miniconda3-latest-Linux-x86_64.sh -b && \
+    rm ./Miniconda3-latest-Linux-x86_64.sh

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,75 @@
+{
+    "name": "GPT4RoI",
+    "build": {
+        "dockerfile": "Dockerfile",
+        "context": "..",
+        "args": {}
+    },
+    "features": {
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+        "ghcr.io/devcontainers/features/azure-cli:1": {},
+        "ghcr.io/devcontainers/features/powershell:1": {},
+        "ghcr.io/devcontainers/features/common-utils:2": {},
+        "ghcr.io/devcontainers-contrib/features/zsh-plugins:0": {},
+    },
+    // "forwardPorts": [],
+    "postCreateCommand": "bash ./.devcontainer/postCreateCommand.sh",
+    "customizations": {
+        "vscode": {
+            "settings": {
+                "python.analysis.autoImportCompletions": true,
+                "python.analysis.autoImportUserSymbols": true,
+                "python.defaultInterpreterPath": "~/miniconda3/envs/gpt4roi/bin/python",
+                "python.formatting.provider": "black",
+                "python.linting.enabled": true,
+                "python.linting.flake8Enabled": true,
+                "isort.check": true,
+                "dev.containers.copyGitConfig": true,
+                "terminal.integrated.defaultProfile.linux": "zsh",
+                "terminal.integrated.profiles.linux": {
+                    "zsh": {
+                        "path": "/usr/bin/zsh"
+                    },
+                },
+                "[python]": {
+                }
+            },
+            "extensions": [
+                "aaron-bond.better-comments",
+                "eamodio.gitlens",
+                "EditorConfig.EditorConfig",
+                "foxundermoon.shell-format",
+                "GitHub.copilot-chat",
+                "GitHub.copilot",
+                "lehoanganh298.json-lines-viewer",
+                "mhutchie.git-graph",
+                "ms-azuretools.vscode-docker",
+                "ms-dotnettools.dotnet-interactive-vscode",
+                "ms-python.black-formatter",
+                "ms-python.flake8",
+                "ms-python.isort",
+                "ms-python.python",
+                "ms-python.vscode-pylance",
+                "njpwerner.autodocstring",
+                "redhat.vscode-yaml",
+                "stkb.rewrap",
+                "yzhang.markdown-all-in-one",
+                "mechatroner.rainbow-csv",
+                "dotenv.dotenv-vscode",
+                "alefragnani.Bookmarks"
+            ]
+        }
+    },
+    "mounts": [
+    ],
+    "runArgs": [
+        "--gpus",
+        "all",
+        // "--ipc",
+        // "host",
+        "--ulimit",
+        "memlock=-1",
+        "--env-file",
+        ".devcontainer/devcontainer.env"
+    ],
+}

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,0 +1,81 @@
+git config --global safe.directory '*'
+git config --global core.editor "code --wait"
+git config --global pager.branch false
+
+# Activate conda by default
+echo "source /home/vscode/miniconda3/bin/activate" >> ~/.zshrc
+echo "source /home/vscode/miniconda3/bin/activate" >> ~/.bashrc
+
+# Use gpt4roi environment by default
+echo "conda activate gpt4roi" >> ~/.zshrc
+echo "conda activate gpt4roi" >> ~/.bashrc
+
+# Activate conda on current shell
+source /home/vscode/miniconda3/bin/activate
+
+# Create and activate gpt4roi environment
+conda create -y -n gpt4roi python=3.9
+conda activate gpt4roi
+
+echo "Installing CUDA..."
+# Even though cuda package installs cuda-nvcc, it doesn't pin the same version so we explicitly set both
+conda install -y -c nvidia cuda=11.7 cuda-nvcc=11.7
+
+export CUDA_HOME=/home/vscode/miniconda3/envs/gpt4roi
+echo "export CUDA_HOME=$CUDA_HOME" >> ~/.zshrc
+echo "export CUDA_HOME=$CUDA_HOME" >> ~/.bashrc
+
+pip install --upgrade pip
+pip install setuptools_scm
+pip install --no-cache-dir -e .
+
+# please use conda re-install the torch, pip may loss some runtime lib
+conda install -y -c nvidia -c pytorch pytorch-cuda=11.7 pytorch=1.10.0 torchvision=0.11.1 torchaudio=0.10.0
+
+pip install ninja
+pip install flash-attn --no-build-isolation
+
+MMCV_WITH_OPS=1 pip install -e mmcv-1.4.7
+
+git clone https://huggingface.co/jeffwan/llama-7b-hf ./llama-7b
+git clone https://huggingface.co/shilongz/GPT4RoI-7B-delta-V0 ./GPT4RoI-7B-delta
+
+export PYTHONPATH=`pwd`:$PYTHONPATH
+python3 -m scripts.apply_delta \
+    --base ./llama-7b \
+    --target ./GPT4RoI-7B \
+    --delta ./GPT4RoI-7B-delta
+
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
+
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+
+nvm install 18.16.0
+
+curl -fsSL https://get.pnpm.io/install.sh | sh -
+
+export PNPM_HOME="/home/vscode/.local/share/pnpm"
+case ":$PATH:" in
+  *":$PNPM_HOME:"*) ;;
+  *) export PATH="$PNPM_HOME:$PATH" ;;
+esac
+
+source ~/.zshrc
+
+pnpm --version
+
+git clone https://github.com/ShoufaChen/gradio-dev.git
+cd gradio-dev
+bash scripts/build_frontend.sh
+pip install -e .
+cd ..
+
+node -v
+npm -v
+nvcc -V
+TORCH_VERSION=$(python -c "import torch;print(torch.__version__)")
+echo "Torch version: $TORCH_VERSION"
+
+echo "postCreateCommand.sh completed!"

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+# 4 space indentation
+[*.{py,json}]
+indent_style = space
+indent_size = 4
+
+# 2 space indentation
+[*.{md,sh,yaml,yml}]
+indent_style = space
+indent_size = 2

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+# Flake8 Options: https://flake8.pycqa.org/en/latest/user/options.html#index-of-options
+max-line-length = 120
+ignore = F541, E501, F841

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,29 @@
+# https://git-scm.com/docs/gitattributes
+
+# Set the default behavior, in case people don't have core.autocrlf set.
+# https://git-scm.com/docs/gitattributes#_end_of_line_conversion
+* text=auto
+
+# common python attributes, taken from https://github.com/alexkaratarakis/gitattributes/blob/710900479a2bedeec7003d381719521ffbb18bf8/Python.gitattributes
+# Source files
+# ============
+*.pxd    text diff=python
+*.py     text diff=python
+*.py3    text diff=python
+*.pyw    text diff=python
+*.pyx    text diff=python
+*.pyz    text diff=python
+*.pyi    text diff=python
+
+# Binary files
+# ============
+*.db     binary
+*.p      binary
+*.pkl    binary
+*.pickle binary
+*.pyc    binary export-ignore
+*.pyo    binary export-ignore
+*.pyd    binary
+
+# Jupyter notebook
+*.ipynb  text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,28 @@ output
 
 checkpoints
 ckpts*
+
+# Secret Environment Variables
+.env*
+
+# Amulet User Config
+.amltconfig
+
+# Devcontainer
+!.devcontainer/*
+
+# Blob Fuse
+.blobfuse/*.yaml
+!.blobfuse/*.example.yaml
+
+# Pretrained Models
+models
+llama-7b
+GPT4RoI-7B-delta
+GPT4RoI-7B
+
+# Gradio Box
+gradio-dev
+
+# Pnpm
+.pnpm-store

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ You can also directly download the file from this [webpage](https://huggingface.
 Apply the delta weights to the original LLaMA-7B weights. Note that this conversion command requires approximately 30 GB of CPU RAM.
 ```bash
 export PYTHONPATH=`pwd`:$PYTHONPATH
-python3 -m scripts.apply_delta.py \
+python3 -m scripts.apply_delta \
     --base ./llama-7b \
     --target ./GPT4RoI-7B \
     --delta ./GPT4RoI-7B-delta


### PR DESCRIPTION
## Issue

The setup for GPT4RoI repo is complicated and can become a large barrier for others to contribute.

## Solution

Use [.devcontainer](https://code.visualstudio.com/docs/devcontainers/containers) to _**standardize**_ development environment and _**automate**_ installation steps

Automates (see .devcontainer/postCreateCommand.sh)
- Guarantees correct versions of python, cuda, cuda compiler and torch to allow building the packages using native C++ compilation such as `flash-attn` and `mmcv`
- Installation of root package
- Downloading of pretrained models `llama-7b-hf` and `GPT4RoI-7B-delta-V0` and run script to apply delta
- Installation of NVM, install node, install pnpm, clone gradio-box, and build package for usage in demo

## [Video](https://youtu.be/0MWkGHKVrdE)

I likely won't be able to work more on this, but I thought it could be useful for others.